### PR TITLE
Fix code scanning alert no. 1: Prototype-polluting assignment

### DIFF
--- a/src/Event.js
+++ b/src/Event.js
@@ -41,6 +41,9 @@ const subscribe = (...args) => {
 
   console.debug("react-event", "subscribe", type, id);
 
+  if (type === '__proto__' || type === 'constructor' || type === 'prototype') {
+    throw new Error("Invalid subscription type");
+  }
   if (!subscriptions[type]) {
     subscriptions[type] = {};
   }
@@ -81,6 +84,9 @@ const publish = (...args) => {
   console.log("react-event", "publish", type, payload);
   messages.set(type, payload);
 
+  if (type === '__proto__' || type === 'constructor' || type === 'prototype') {
+    throw new Error("Invalid publish type");
+  }
   Object.keys(subscriptions[type] || {}).forEach((key) => {
     const registry = subscriptions[type][key];
 


### PR DESCRIPTION
Fixes [https://github.com/NucleoidAI/react-event/security/code-scanning/1](https://github.com/NucleoidAI/react-event/security/code-scanning/1)

To fix the prototype pollution vulnerability, we need to ensure that the `type` variable cannot be set to dangerous values like `__proto__`, `constructor`, or `prototype`. We can achieve this by adding a check to reject these values before using them as keys in the `subscriptions` object.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
